### PR TITLE
Signal main loop to exit when stop finds no runner instances

### DIFF
--- a/lib/process_bot/process.rb
+++ b/lib/process_bot/process.rb
@@ -122,6 +122,11 @@ class ProcessBot::Process # rubocop:disable Metrics/ClassLength
     logger.logs "Stop process #{args}"
     @stopped = true
     handler_instance.stop
+
+    if runner_instances.empty?
+      logger.logs "No runner instances remaining, signaling main loop to exit"
+      runner_events << {type: :stopped, runner_instance: nil}
+    end
   end
 
   def run

--- a/spec/process_bot/process_spec.rb
+++ b/spec/process_bot/process_spec.rb
@@ -246,6 +246,22 @@ describe ProcessBot::Process do
     end
   end
 
+  describe "#stop" do
+    it "signals the main loop to exit when no runner instances remain" do
+      options = ProcessBot::Options.new(handler: "custom")
+      process = ProcessBot::Process.new(options)
+      runner_events = process.send(:runner_events)
+
+      expect(process.handler_instance).to receive(:stop)
+
+      process.stop
+
+      expect(process.stopped).to be true
+      event = runner_events.pop(true)
+      expect(event).to include(type: :stopped, runner_instance: nil)
+    end
+  end
+
   describe "#restart" do
     it "starts a replacement sidekiq when overlap is enabled" do
       options = ProcessBot::Options.new(handler: "sidekiq", sidekiq_restart_overlap: true)


### PR DESCRIPTION
## Summary
- When the custom handler `stop` returned with no active runner, the main loop was blocked on `runner_events.pop` with nothing to wake it up
- Process_bot hung forever, holding the control port and screen session, causing duplicate sessions and port conflicts on redeploy
- Now `Process#stop` pushes a synthetic event to unblock the main loop so process_bot exits cleanly

## Test plan
- [x] All 21 specs pass
- [x] New spec verifies the synthetic event is pushed when no runner instances remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)