### PR TITLE
Include Gemfile.lock in rake release commits

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -104,7 +104,8 @@ private
       )
     )
 
-    run!("git", "add", VERSION_FILE.to_s)
+    run!("bundle", "lock")
+    run!("git", "add", VERSION_FILE.to_s, "Gemfile.lock")
   end
 
   def commit!(next_version)


### PR DESCRIPTION
## Summary
- `rake release:patch` (and `:minor`/`:major`/`:rubygems`) bumped `lib/process_bot/version.rb` and committed only that file. Because `Gemfile.lock`'s `PATH` block pins the gem version, the next `bundle` run rewrote the lockfile, leaving an uncommitted change for someone to clean up manually (e.g. the separate `Bumped to 29` commit on master).
- `bump_version!` now runs `bundle lock` to refresh `Gemfile.lock` and stages both files so the release commit carries the matching PATH entry.
- Restores the behavior originally added in aeba302 that was removed in PR #191.

## Test plan
- [ ] Dry-run a patch release locally and confirm the release commit includes both `lib/process_bot/version.rb` and `Gemfile.lock`.