### PR TITLE
Harden ProcessBot stale process matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 - Drop Ruby 2.x support. Minimum Ruby is now 3.2; CI covers 3.2/3.3/3.4 and RuboCop's `TargetRubyVersion` follows. Shorthand anonymous forwarding (`*, **, &`) is applied where it replaces redundant `*args, **opts, &block` pass-throughs.
 - Fail `start_tcp_server` when another ProcessBot with the same `--id` is already running instead of silently drifting to a new port. Port drift across unrelated services is still supported; drift for a duplicate id was the root cause of Capistrano deploys leaving a stale previous-release ProcessBot alive on a drifted port while every subsequent `stop --port X` hit the wrong instance.
+- Treat legacy ProcessBot titles without `application_basename` as duplicates when they share the same `--id` and control port, and include the same legacy match in forced stop diagnostics.
 - Stop accepting new control commands during shutdown so in-flight responses complete reliably.
 - Stream ProcessBot logs to connected control clients for Capistrano output.
 - Sanitize broadcast log output to keep JSON encoding safe.

--- a/lib/process_bot/control_socket.rb
+++ b/lib/process_bot/control_socket.rb
@@ -74,8 +74,25 @@ class ProcessBot::ControlSocket
 
   def find_duplicate_id_entries(id, basename)
     running_process_bot_entries.select do |entry|
-      entry[:id] == id && entry[:application_basename] == basename
+      duplicate_id_entry_matches?(entry, id, basename)
     end
+  end
+
+  def duplicate_id_entry_matches?(entry, id, basename)
+    return false unless entry[:id] == id
+    return true if basename && entry[:application_basename] == basename
+
+    legacy_entry_without_application?(entry) && same_control_port?(entry)
+  end
+
+  def legacy_entry_without_application?(entry)
+    entry[:application].nil? && entry[:application_basename].nil?
+  end
+
+  def same_control_port?(entry)
+    return false unless entry[:port] && options[:port]
+
+    entry[:port].to_i == options[:port].to_i
   end
 
   def duplicate_id_error_message(id, duplicates)
@@ -235,15 +252,19 @@ class ProcessBot::ControlSocket
         next
       end
 
-      pid = process.data["pid"] || process.pid
-      entries << {
-        application_basename: process_data["application_basename"],
-        id: process_data["id"]&.to_s,
-        pid: pid,
-        port: process_data["port"]&.to_i
-      }
+      entries << process_bot_entry_from_process_data(process, process_data)
     end
 
     entries
+  end
+
+  def process_bot_entry_from_process_data(process, process_data)
+    {
+      application: process_data["application"],
+      application_basename: process_data["application_basename"],
+      id: process_data["id"]&.to_s,
+      pid: process.data["pid"] || process.pid,
+      port: process_data["port"]&.to_i
+    }
   end
 end

--- a/lib/process_bot/control_socket.rb
+++ b/lib/process_bot/control_socket.rb
@@ -82,11 +82,7 @@ class ProcessBot::ControlSocket
     return false unless entry[:id] == id
     return true if basename && entry[:application_basename] == basename
 
-    legacy_entry_without_application?(entry) && same_control_port?(entry)
-  end
-
-  def legacy_entry_without_application?(entry)
-    entry[:application].nil? && entry[:application_basename].nil?
+    entry[:application_basename].nil? && same_control_port?(entry)
   end
 
   def same_control_port?(entry)

--- a/lib/process_bot/options.rb
+++ b/lib/process_bot/options.rb
@@ -36,17 +36,21 @@ class ProcessBot::Options
   end
 
   def application_basename
-    @application_basename ||= begin
-      app_path_parts = release_path.split("/")
+    @application_basename ||= application_basename_from_release_path
+  end
 
-      if release_path.include?("/releases/")
-        app_path_parts.pop(2)
-      elsif release_path.end_with?("/current")
-        app_path_parts.pop
-      end
+  def application_basename_from_release_path
+    app_path_parts = release_path.split("/")
 
-      app_path_parts.last
+    if (releases_index = app_path_parts.index("releases"))
+      return app_path_parts[0...releases_index].last
     end
+
+    if (current_index = app_path_parts.index("current"))
+      return app_path_parts[0...current_index].last
+    end
+
+    app_path_parts.last
   end
 
   def possible_process_titles

--- a/lib/process_bot/options.rb
+++ b/lib/process_bot/options.rb
@@ -41,14 +41,12 @@ class ProcessBot::Options
 
   def application_basename_from_release_path
     app_path_parts = release_path.split("/")
+    deployment_marker_index = [
+      app_path_parts.rindex("releases"),
+      app_path_parts.rindex("current")
+    ].compact.max
 
-    if (releases_index = app_path_parts.index("releases"))
-      return app_path_parts[0...releases_index].last
-    end
-
-    if (current_index = app_path_parts.index("current"))
-      return app_path_parts[0...current_index].last
-    end
+    return app_path_parts[0...deployment_marker_index].last if deployment_marker_index
 
     app_path_parts.last
   end

--- a/lib/process_bot/process.rb
+++ b/lib/process_bot/process.rb
@@ -361,8 +361,7 @@ class ProcessBot::Process # rubocop:disable Metrics/ClassLength
   def legacy_process_bot_port_matches?(process_data)
     return false unless process_data["port"] && options[:port]
 
-    process_data["application"].nil? &&
-      process_data["application_basename"].nil? &&
+    process_data["application_basename"].nil? &&
       process_data["port"].to_i == options[:port].to_i
   end
 

--- a/lib/process_bot/process.rb
+++ b/lib/process_bot/process.rb
@@ -334,9 +334,36 @@ class ProcessBot::Process # rubocop:disable Metrics/ClassLength
   end
 
   def process_bot_process_line_matches?(line)
-    line.include?("ProcessBot {") &&
-      line.include?("\"application\":\"#{options[:application]}\"") &&
-      line.include?("\"id\":\"#{options[:id]}\"")
+    process_data = process_bot_data_from_line(line)
+    return false unless process_data
+    return false unless process_data["id"]&.to_s == options[:id].to_s
+
+    process_bot_application_matches?(process_data) || legacy_process_bot_port_matches?(process_data)
+  end
+
+  def process_bot_data_from_line(line)
+    match = line.match(/ProcessBot (\{.+\})/)
+    return unless match
+
+    JSON.parse(match[1])
+  rescue JSON::ParserError
+    nil
+  end
+
+  def process_bot_application_matches?(process_data)
+    application = options[:application]
+    return true if application && process_data["application"] == application
+
+    basename = safe_application_basename
+    basename && process_data["application_basename"] == basename
+  end
+
+  def legacy_process_bot_port_matches?(process_data)
+    return false unless process_data["port"] && options[:port]
+
+    process_data["application"].nil? &&
+      process_data["application_basename"].nil? &&
+      process_data["port"].to_i == options[:port].to_i
   end
 
   def force_stop_process_bot_if_configured(matching_processes)

--- a/spec/process_bot/control_socket_spec.rb
+++ b/spec/process_bot/control_socket_spec.rb
@@ -53,10 +53,34 @@ describe ProcessBot::ControlSocket do
       control_socket = ProcessBot::ControlSocket.new(options: options, process: process)
 
       allow(control_socket).to receive(:running_process_bot_entries).and_return([
-                                                                                  {application_basename: "my-app", id: "sidekiq-main", pid: 12_345, port: 9095}
+                                                                                  {
+                                                                                    application: nil,
+                                                                                    application_basename: "my-app",
+                                                                                    id: "sidekiq-main",
+                                                                                    pid: 12_345,
+                                                                                    port: 9095
+                                                                                  }
                                                                                 ])
 
       expect { control_socket.start_tcp_server }.to raise_error(/Another process_bot with id="sidekiq-main" is already running/)
+    end
+
+    it "raises for a legacy ProcessBot with the same id and control port" do
+      options = ProcessBot::Options.new(handler: "custom", id: "brainbound-backend", port: 9095, release_path: "/srv/brainbound/releases/20260424000000")
+      process = ProcessBot::Process.new(options)
+      control_socket = ProcessBot::ControlSocket.new(options: options, process: process)
+
+      allow(control_socket).to receive(:running_process_bot_entries).and_return([
+                                                                                  {
+                                                                                    application: nil,
+                                                                                    application_basename: nil,
+                                                                                    id: "brainbound-backend",
+                                                                                    pid: 12_345,
+                                                                                    port: 9095
+                                                                                  }
+                                                                                ])
+
+      expect { control_socket.start_tcp_server }.to raise_error(/Another process_bot with id="brainbound-backend" is already running/)
     end
 
     it "does not raise when running instances have different ids" do
@@ -68,7 +92,7 @@ describe ProcessBot::ControlSocket do
 
       fake_server = instance_double(TCPServer, close: true)
       allow(control_socket).to receive_messages(running_process_bot_entries: [
-                                                  {application_basename: "my-app", id: "other-app", pid: 12_345, port: 9095}
+                                                  {application: nil, application_basename: "my-app", id: "other-app", pid: 12_345, port: 9095}
                                                 ], actually_start_tcp_server: fake_server)
 
       expect { control_socket.start_tcp_server }.not_to raise_error
@@ -83,7 +107,22 @@ describe ProcessBot::ControlSocket do
 
       fake_server = instance_double(TCPServer, close: true)
       allow(control_socket).to receive_messages(running_process_bot_entries: [
-                                                  {application_basename: "app-b", id: "sidekiq-main", pid: 12_345, port: 9095}
+                                                  {application: nil, application_basename: "app-b", id: "sidekiq-main", pid: 12_345, port: 9095}
+                                                ], actually_start_tcp_server: fake_server)
+
+      expect { control_socket.start_tcp_server }.not_to raise_error
+    end
+
+    it "does not raise for a legacy ProcessBot with the same id on a different control port" do
+      options = ProcessBot::Options.new(handler: "custom", id: "brainbound-backend", port: 9095, release_path: "/srv/brainbound/releases/20260424000000")
+      process = ProcessBot::Process.new(options)
+      control_socket = ProcessBot::ControlSocket.new(options: options, process: process)
+
+      allow(control_socket).to receive(:run_client_loop)
+
+      fake_server = instance_double(TCPServer, close: true)
+      allow(control_socket).to receive_messages(running_process_bot_entries: [
+                                                  {application: nil, application_basename: nil, id: "brainbound-backend", pid: 12_345, port: 9096}
                                                 ], actually_start_tcp_server: fake_server)
 
       expect { control_socket.start_tcp_server }.not_to raise_error
@@ -98,7 +137,7 @@ describe ProcessBot::ControlSocket do
 
       fake_server = instance_double(TCPServer, close: true)
       allow(control_socket).to receive_messages(running_process_bot_entries: [
-                                                  {application_basename: "my-app", id: "my-app", pid: 12_345, port: 9095}
+                                                  {application: nil, application_basename: "my-app", id: "my-app", pid: 12_345, port: 9095}
                                                 ], actually_start_tcp_server: fake_server)
 
       expect { control_socket.start_tcp_server }.not_to raise_error

--- a/spec/process_bot/control_socket_spec.rb
+++ b/spec/process_bot/control_socket_spec.rb
@@ -83,6 +83,24 @@ describe ProcessBot::ControlSocket do
       expect { control_socket.start_tcp_server }.to raise_error(/Another process_bot with id="brainbound-backend" is already running/)
     end
 
+    it "raises for a pre-application-basename ProcessBot with application and the same id and control port" do
+      options = ProcessBot::Options.new(handler: "custom", id: "brainbound-backend", port: 9095, release_path: "/srv/brainbound/releases/20260424000000")
+      process = ProcessBot::Process.new(options)
+      control_socket = ProcessBot::ControlSocket.new(options: options, process: process)
+
+      allow(control_socket).to receive(:running_process_bot_entries).and_return([
+                                                                                  {
+                                                                                    application: "brainbound",
+                                                                                    application_basename: nil,
+                                                                                    id: "brainbound-backend",
+                                                                                    pid: 12_345,
+                                                                                    port: 9095
+                                                                                  }
+                                                                                ])
+
+      expect { control_socket.start_tcp_server }.to raise_error(/Another process_bot with id="brainbound-backend" is already running/)
+    end
+
     it "does not raise when running instances have different ids" do
       options = ProcessBot::Options.new(handler: "custom", id: "my-app", port: 9095, release_path: "/srv/my-app")
       process = ProcessBot::Process.new(options)

--- a/spec/process_bot/options_spec.rb
+++ b/spec/process_bot/options_spec.rb
@@ -25,5 +25,11 @@ describe ProcessBot::Options do
 
       expect(options.application_basename).to eq "sample_app_name"
     end
+
+    it "returns the application basename from the nearest deployment marker" do
+      options = ProcessBot::Options.new(release_path: "/srv/current/sample_app_name/current/backend")
+
+      expect(options.application_basename).to eq "sample_app_name"
+    end
   end
 end

--- a/spec/process_bot/options_spec.rb
+++ b/spec/process_bot/options_spec.rb
@@ -8,8 +8,20 @@ describe ProcessBot::Options do
       expect(options.application_basename).to eq "sample_app_name"
     end
 
+    it "returns the application basename from a path inside a release" do
+      options = ProcessBot::Options.new(release_path: "/home/dev/sample_app_name/releases/20221107164955/backend")
+
+      expect(options.application_basename).to eq "sample_app_name"
+    end
+
     it "returns the application basename from the release path (current)" do
       options = ProcessBot::Options.new(release_path: "/home/dev/sample_app_name/current")
+
+      expect(options.application_basename).to eq "sample_app_name"
+    end
+
+    it "returns the application basename from a path inside current" do
+      options = ProcessBot::Options.new(release_path: "/home/dev/sample_app_name/current/backend")
 
       expect(options.application_basename).to eq "sample_app_name"
     end

--- a/spec/process_bot/process_spec.rb
+++ b/spec/process_bot/process_spec.rb
@@ -103,6 +103,30 @@ describe ProcessBot::Process do
       end.not_to raise_error
     end
 
+    it "force-stops legacy matching process bot pid by id and port on nil response when configured" do
+      options = ProcessBot::Options.new(
+        command: "stop",
+        port: 9095,
+        application: "brainbound",
+        id: "brainbound-backend",
+        ignore_no_process_bot: true,
+        force_stop_on_no_response: true,
+        release_path: "/home/dev/brainbound/releases/20260520145138/backend"
+      )
+      process = ProcessBot::Process.new(options)
+
+      expect(process.client).to receive(:send_command).and_return(:nil)
+      expect(Knj::Os).to receive(:shellcmd).with("ps -eo pid,args").and_return(
+        "123 ProcessBot {\"application\":null,\"handler\":\"custom\",\"id\":\"brainbound-backend\",\"pid\":null,\"port\":9095}\n" \
+          "456 ProcessBot {\"application\":null,\"handler\":\"custom\",\"id\":\"brainbound-backend\",\"pid\":null,\"port\":9096}"
+      )
+      expect(Process).to receive(:kill).with("TERM", 123)
+
+      expect do
+        process.execute!
+      end.not_to raise_error
+    end
+
     it "does not force-stop process bot pid on nil response when not configured" do
       options = ProcessBot::Options.new(
         command: "stop",

--- a/spec/process_bot/process_spec.rb
+++ b/spec/process_bot/process_spec.rb
@@ -127,6 +127,30 @@ describe ProcessBot::Process do
       end.not_to raise_error
     end
 
+    it "force-stops pre-application-basename matching process bot pid by id and port on nil response when configured" do
+      options = ProcessBot::Options.new(
+        command: "stop",
+        port: 9095,
+        application: "brainbound",
+        id: "brainbound-backend",
+        ignore_no_process_bot: true,
+        force_stop_on_no_response: true,
+        release_path: "/home/dev/brainbound/releases/20260520145138/backend"
+      )
+      process = ProcessBot::Process.new(options)
+
+      expect(process.client).to receive(:send_command).and_return(:nil)
+      expect(Knj::Os).to receive(:shellcmd).with("ps -eo pid,args").and_return(
+        "123 ProcessBot {\"application\":\"old-brainbound\",\"handler\":\"custom\",\"id\":\"brainbound-backend\",\"pid\":null,\"port\":9095}\n" \
+          "456 ProcessBot {\"application\":\"old-brainbound\",\"handler\":\"custom\",\"id\":\"brainbound-backend\",\"pid\":null,\"port\":9096}"
+      )
+      expect(Process).to receive(:kill).with("TERM", 123)
+
+      expect do
+        process.execute!
+      end.not_to raise_error
+    end
+
     it "does not force-stop process bot pid on nil response when not configured" do
       options = ProcessBot::Options.new(
         command: "stop",


### PR DESCRIPTION
Summary:
- Treat legacy ProcessBot titles without application_basename as duplicates when id and control port match.
- Include that legacy match in forced stop diagnostics.
- Derive application_basename correctly for paths inside releases/current.

Tests:
- source /home/dev/.rvm/scripts/rvm && rvm use ruby-3.4.6 && bundle exec rspec spec/process_bot/control_socket_spec.rb spec/process_bot/process_spec.rb spec/process_bot/options_spec.rb
- source /home/dev/.rvm/scripts/rvm && rvm use ruby-3.4.6 && bundle exec rubocop lib/process_bot/control_socket.rb lib/process_bot/process.rb lib/process_bot/options.rb spec/process_bot/control_socket_spec.rb spec/process_bot/process_spec.rb spec/process_bot/options_spec.rb